### PR TITLE
FEATURE: DOCUMENT ENTIRE ANNOTATIONS

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -155,6 +155,7 @@ class Application @Inject() (cache: CacheApi) extends Controller {
         controllers.routes.javascript.EntityController.getMergedEntities,
         controllers.routes.javascript.EntityController.undoBlacklistingByIds,
         controllers.routes.javascript.EntityController.whitelistEntity,
+        controllers.routes.javascript.EntityController.whitelistEntityOffset,
         controllers.routes.javascript.EntityController.undoMergeByIds,
         controllers.routes.javascript.EntityController.undoMergeKeywords,
         controllers.routes.javascript.EntityController.getEntitiesByDoc,

--- a/app/controllers/EntityController.scala
+++ b/app/controllers/EntityController.scala
@@ -141,6 +141,21 @@ class EntityController @Inject() (
   }
 
   /**
+   * whitelist entity offset
+   *
+   * @param text the entity to whitelist.
+   * @param start start the offset position.
+   * @param end end the offset position.
+   * @param entId entity id
+   * @param docId document id
+   *
+   */
+  def whitelistEntityOffset(text: String, start: String, end: String, docId: String, entId: String) = Action { implicit request =>
+    entityService.whitelistOffset(text, start.toInt, end.toInt, BigInt(entId), BigInt(docId))(currentDataset)
+    Ok("success").as("Text")
+  }
+
+  /**
    * Withdraws [[models.services.EntityService#merge]] for the given entity id.
    *
    * @param focalIds the central entity ids.

--- a/app/models/services/EntityService.scala
+++ b/app/models/services/EntityService.scala
@@ -116,6 +116,21 @@ trait EntityService {
    * @param start the start of entity offset.
    * @param end the end of entity offset.
    * @param index the data source index or database name to query.
+   * @param docId the identifier of document
+   * @return ''true'', if all entities are successfully marked as blacklisted. ''False'' if at least one entity
+   * is not correct marked.
+   */
+  def whitelistOffset(text: String, start: Int, end: Int, entId: BigInt, docId: BigInt)(index: String): Boolean
+
+  /**
+   * Marks the entity to whitelist.
+   *
+   * Whitelist new entity
+   *
+   * @param text the entity text to whitelist.
+   * @param start the start of entity offset.
+   * @param end the end of entity offset.
+   * @param index the data source index or database name to query.
    * @param entId the identifier of entity
    * @param docId the identifier of document
    * @return ''true'', if all entities are successfully marked as blacklisted. ''False'' if at least one entity
@@ -295,6 +310,13 @@ class DBEntityService extends EntityService {
     sql"DELETE FROM entityoffset WHERE docId=${docId} AND entitystart=${start} AND entityend=${end}".update().apply()
     sql"""INSERT INTO entityoffset (docid, entid, entitystart, entityend)
          VALUES (${docId}, (SELECT coalesce(max(id),0) FROM entity), ${start}, ${end})""".update().apply()
+    true
+  }
+
+  /** @inheritdoc */
+  override def whitelistOffset(text: String, start: Int, end: Int, entId: BigInt, docId: BigInt)(index: String): Boolean = db(index).localTx { implicit session =>
+    sql"""INSERT INTO entityoffset (docid, entid, entitystart, entityend)
+         VALUES (${docId}, ${entId}, ${start}, ${end})""".update().apply()
     true
   }
 

--- a/conf/routes
+++ b/conf/routes
@@ -26,6 +26,26 @@ GET        /getNeighborCounts                     controllers.NetworkController.
 GET        /getNeighbors                          controllers.NetworkController.getNeighbors(fullText: List[String], generic: Map[String, List[String]], entities: List[Long], timeRange: String, timeExprRange: String, currentNetwork: List[Long], focalNode: Long)
 GET        /changeEntityNameById                  controllers.NetworkController.changeEntityNameById(id: Long, newName: String)
 GET        /changeEntityTypeById                  controllers.NetworkController.changeEntityTypeById(id: Long, newType: String)
+GET        /getEntities                           controllers.EntityController.getEntitiesByType(fullText: List[String], generic: Map[String, List[String]], entities: List[Long], timeRange: String, timeExprRange: String, size: Int, entityType: String, filter: List[Long])
+GET        /getRecordedEntity                     controllers.EntityController.getRecordedEntity(text: String, enType: String)
+GET        /getEntityTypes                        controllers.EntityController.getEntityTypes
+GET        /getBlacklisted                        controllers.EntityController.getBlacklistedEntities
+GET        /getBlacklistedKeywords                controllers.EntityController.getBlacklistedKeywords
+GET        /getMerged                             controllers.EntityController.getMergedEntities
+GET        /undoBlacklisting                      controllers.EntityController.undoBlacklistingByIds(ids: List[Long])
+GET        /undoMerge                             controllers.EntityController.undoMergeByIds(focalIds: List[Long])
+GET        /undoMergeKeywords                     controllers.EntityController.undoMergeKeywords(focalTerms: List[String])
+GET        /getEntitiesByDoc                      controllers.EntityController.getEntitiesByDoc(id: Long)
+GET        /getBlacklistsByDoc                    controllers.EntityController.getBlacklistsByDoc(id: Long)
+GET        /getMetadata                           controllers.MetadataController.getMetadata(fullText: List[String], generic: Map[String, List[String]], entities: List[Long], timeRange: String, timeExprRange: String)
+GET        /getMetadataTypes                      controllers.MetadataController.getMetadataTypes
+GET        /getSpecificMetadata                   controllers.MetadataController.getSpecificMetadata(fullText: List[String], key: String, generic: Map[String, List[String]], entities: List[Long], instances: List[String], timeRange: String, timeExprRange: String)
+GET        /getTimeline                           controllers.HistogramController.getTimeline(fullText: List[String], generic: Map[String, List[String]], entities: List[Long], timeRange: String, timeExprRange: String, lod: String)
+GET        /getTimeExprTimeline                   controllers.HistogramController.getTimeExprTimeline(fullText: List[String], generic: Map[String, List[String]], entities: List[Long], timeRange: String, timeExprRange: String, lod: String)
+GET        /getTimelineLOD                        controllers.HistogramController.getTimelineLOD
+
+# Newsleak V.2.0.0 Routes
+
 GET        /induceSubgraphKeyword                 controllers.KeywordNetworkController.induceSubgraphKeyword(fullText: List[String], generic: Map[String, List[String]], entities: List[Long], keywords: List[String], timeRange: String, timeExprRange: String, nodeFraction: Map[String, String])
 GET        /addNodeKeyword                        controllers.KeywordNetworkController.addNodesKeyword(fullText: List[String], generic: Map[String, List[String]], entities: List[Long], timeRange: String, timeExprRange: String, currentNetwork: List[String], nodes: List[String])
 GET        /blacklistEntitiesByIdKeyword          controllers.KeywordNetworkController.blacklistEntitiesByIdKeyword(ids: List[Long])
@@ -40,26 +60,10 @@ GET        /getTags                               controllers.KeywordNetworkCont
 GET        /setTagKeywordRelation                 controllers.KeywordNetworkController.setTagKeywordRelation(tag: String, keywords: List[String], frequencies: List[Long])
 GET        /clearTagKeywordRelation               controllers.KeywordNetworkController.resetTagKeywordRelation
 GET        /getHostAddress                        controllers.KeywordNetworkController.getHostAddress
-GET        /getEntities                           controllers.EntityController.getEntitiesByType(fullText: List[String], generic: Map[String, List[String]], entities: List[Long], timeRange: String, timeExprRange: String, size: Int, entityType: String, filter: List[Long])
-GET        /getRecordedEntity                     controllers.EntityController.getRecordedEntity(text: String, enType: String)
-GET        /getEntityTypes                        controllers.EntityController.getEntityTypes
-GET        /getBlacklisted                        controllers.EntityController.getBlacklistedEntities
-GET        /getBlacklistedKeywords                controllers.EntityController.getBlacklistedKeywords
-GET        /getMerged                             controllers.EntityController.getMergedEntities
-GET        /undoBlacklisting                      controllers.EntityController.undoBlacklistingByIds(ids: List[Long])
-GET        /whitelistEntity                       controllers.EntityController.whitelistEntity(text: String, start: String, end: String, enType: String, docId: String, entId: String)
-GET        /undoMerge                             controllers.EntityController.undoMergeByIds(focalIds: List[Long])
-GET        /undoMergeKeywords                     controllers.EntityController.undoMergeKeywords(focalTerms: List[String])
-GET        /getEntitiesByDoc                      controllers.EntityController.getEntitiesByDoc(id: Long)
-GET        /getBlacklistsByDoc                    controllers.EntityController.getBlacklistsByDoc(id: Long)
-GET        /getMetadata                           controllers.MetadataController.getMetadata(fullText: List[String], generic: Map[String, List[String]], entities: List[Long], timeRange: String, timeExprRange: String)
-GET        /getMetadataTypes                      controllers.MetadataController.getMetadataTypes
-GET        /getSpecificMetadata                   controllers.MetadataController.getSpecificMetadata(fullText: List[String], key: String, generic: Map[String, List[String]], entities: List[Long], instances: List[String], timeRange: String, timeExprRange: String)
-GET        /getTimeline                           controllers.HistogramController.getTimeline(fullText: List[String], generic: Map[String, List[String]], entities: List[Long], timeRange: String, timeExprRange: String, lod: String)
-GET        /getTimeExprTimeline                   controllers.HistogramController.getTimeExprTimeline(fullText: List[String], generic: Map[String, List[String]], entities: List[Long], timeRange: String, timeExprRange: String, lod: String)
-GET        /getTimelineLOD                        controllers.HistogramController.getTimelineLOD
 
-# Newsleak V.2.0.0 Routes
+GET        /whitelistEntity                       controllers.EntityController.whitelistEntity(text: String, start: String, end: String, enType: String, docId: String, entId: String)
+GET        /whitelistEntityOffset                 controllers.EntityController.whitelistEntityOffset(text: String, start: String, end: String, docId: String, entId: String)
+
 GET        /getESEntitiesByDoc                    controllers.DocumentController.getESEntitiesByDoc(id: String)
 GET        /getKeywordsByDoc                      controllers.DocumentController.getKeywordsByDoc(id: String)
 GET        /retrieveKeywords                      controllers.DocumentController.retrieveKeywords(id: String)


### PR DESCRIPTION
In this feature, we enable to annotate the entire entities in the selected document. E.g: We annotate/whitelist Bill as a PERson, so the bill words in that document will be annotated. This feature solves annoying bugs when we annotate only one entity in the doc.